### PR TITLE
Individual topic modal frontend

### DIFF
--- a/client/src/components/IndividualTopicModalComponent/IndividualTopicModalComponent.jsx
+++ b/client/src/components/IndividualTopicModalComponent/IndividualTopicModalComponent.jsx
@@ -1,0 +1,47 @@
+import React from "react";
+
+const IndividualTopicModalComponent = ({ isOpen, onClose, topic, onReview }) => {
+
+    if (!isOpen) return null;
+
+    console.log('Topic Description:', topic);
+
+    const handleReview = () => {
+    onReview(topic);
+    onClose(); 
+  };
+
+
+  return (
+    <div className="fixed top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2">
+      <div className="w-full max-w-[570px] rounded-[20px] bg-white py-12 px-8 text-center md:py-[60px] md:px-[70px]">
+        <h3 class="text-gray-900 pb-2 text-xl font-bold sm:text-2xl">{topic.topic_name}</h3>
+        <span class="bg-blue-500 mx-auto mb-6 inline-block h-1 w-[90px] rounded"></span>
+        <p class="text-gray-500 mb-10 text-base leading-relaxed">{topic.description}</p>
+        <p class="text-blue-500 mb-10 text-base leading-relaxed">
+            <a href={topic.reference_link}>
+                  More info
+            </a>
+        </p>
+        <div class="flex flex-wrap gap-4">
+    <div class="flex-1">
+      <button class="bg-blue-500 whitespace-nowrap border-blue-500 block w-full rounded-lg border p-3 text-center text-base font-medium text-white transition hover:bg-opacity-90"
+          onClick={() => handleReview(topic)}
+        >
+          Reviewed
+        </button>
+        </div>
+    <div class="flex-1">
+      <button class="text-gray-900 block w-full rounded-lg border border-gray-200 p-3 text-center text-base font-medium transition hover:border-red-600 hover:bg-red-600 hover:text-white"
+       onClick={onClose}>
+          Cancel
+        </button>
+      </div>
+      </div>
+      </div>
+    </div>
+  );
+
+}
+
+export default IndividualTopicModalComponent;

--- a/client/src/components/personalDashboard/personalDashboard.jsx
+++ b/client/src/components/personalDashboard/personalDashboard.jsx
@@ -1,12 +1,14 @@
 import React, {useState, useEffect} from "react";
 import ModuleDropdown from "../dashboard/ModuleDropdown";
 import { useAuth0 } from "@auth0/auth0-react";
+import IndividualTopicModalComponent from "../IndividualTopicModalComponent/IndividualTopicModalComponent";
 
 
 const PersonalDashboard = () => {
 
 const { user } = useAuth0();
 const [userTopics, setUserTopics] = useState({ modules: [] });
+const [selectedTopic, setSelectedTopic] = useState(null);
 const { sub } = user
 
 useEffect(() => {
@@ -22,13 +24,21 @@ useEffect(() => {
 
 let rowNumber = 0;
 
+const openModal = (topic) => {
+    setSelectedTopic(topic);
+  };
+
+  const closeModal = () => {
+    setSelectedTopic(null);
+  };
+
   return (
-    <div className="p-4 bg-dark-purple">
+    <div className="p-4 bg-dark-purple w-full">
       <div className="flex justify-center mb-4 text-white">
         <ModuleDropdown />
       </div>
       <table className="w-full border border-collapse border-gray-300 bg-sky-900 text-white">
-        <thead className="bg-amber-300 text-black">
+        <thead className="bg-amber-300 text-black" >
           <tr>
             <th className="border-b p-3 font-bold text-center">#</th>
             <th className="border-b p-3 font-bold text-center">Topic Name</th>
@@ -39,16 +49,32 @@ let rowNumber = 0;
         </thead>
         <tbody>
           {userTopics.modules.map((topic) => (
-            <tr key={topic.entry_id} className="hover:bg-amber-300">
+            <tr key={topic.entry_id} 
+                className="hover:bg-amber-300 hover:text-black">
               <td className="border-b p-3 text-center">{++rowNumber}</td>
-              <td className="border-b p-3 text-center">{topic.topic_name}</td>
+              <td className="border-b p-3 text-center cursor-pointer"
+              onClick={() => openModal(topic)}>
+                {topic.topic_name}</td>
               <td className="border-b p-3 text-center">{topic.module_name}</td>
-              <td className="border-b p-3 text-center">{topic.reference_link}</td>
+              <td className="border-b p-3 text-center">
+                <a href={topic.reference_link}>
+                  Review Link
+                </a>
+              </td>
               <td className="border-b p-3 text-center">{new Date(topic.due_date).toDateString()}</td>
             </tr>
           ))}
         </tbody>
       </table>
+      <IndividualTopicModalComponent
+        isOpen={!!selectedTopic}
+        onClose={closeModal}
+        topic={selectedTopic || {}}
+        onReview={(topic) => {
+          console.log("Topic reviewed:", topic);
+          closeModal(); 
+        }}
+      />
     </div>
   );
 }

--- a/server/endPoints-file/dataForTableEndpoint.js
+++ b/server/endPoints-file/dataForTableEndpoint.js
@@ -11,6 +11,7 @@ const getDataForTable = async (req, res) => {
         modules.name AS module_name,
         topics.topic_name,
         topics.reference_link,
+        topics.description,
         ltt.due_date
       FROM
         learning_topics_tracker ltt


### PR DESCRIPTION
- Create IndividualTopicModalComponent for displaying and reviewing individual topics when you click on the topic's name in the dashboard table.
- Added IndividualTopicModalComponent to PersonalDashboard, sending isOpen, onClose, topic, and onReview props to IndividualTopicModalComponent.
- Changed the size of the dashboard to full, ensuring the same background and eliminating excessive white space.
- Changed the link view.
- Added 'cursor-pointer' and an onClick function for the topic name.
- Added topics.description to the query.

![Screen Shot 2023-12-04 at 19 09 53](https://github.com/Abubakar-Meigag/FinalProject-DejaReview-teamUnity-Ldn10/assets/113217019/b828cf67-74f7-42ad-80a1-48aceed7651e)

![Screen Shot 2023-12-04 at 19 10 13](https://github.com/Abubakar-Meigag/FinalProject-DejaReview-teamUnity-Ldn10/assets/113217019/7bedffd5-c34d-4efc-96fe-96cbb5e0514d)

